### PR TITLE
bugfix/RHT-4505-Upload-to-docuware-not-possible-after-release-4.0.0

### DIFF
--- a/docuware-connector-demo/config/variables.yaml
+++ b/docuware-connector-demo/config/variables.yaml
@@ -11,3 +11,4 @@ Variables:
     username: ''
     password: ''
     hostid: ''
+    organization: ''

--- a/docuware-connector/config/rest-clients.yaml
+++ b/docuware-connector/config/rest-clients.yaml
@@ -17,6 +17,7 @@ RestClients:
       http.protocol.handle-redirects: 'true'
       JSON.Serialization.PROPERTY_INCLUSION: NON_NULL
       jersey.config.client.connectTimeout: ${ivy.var.docuware-connector.connectTimeout}
+      Organization: ${ivy.var.docuware-connector.organization}
     OpenAPI:
       SpecUrl: file:///X:/AxonIvy/marketplace/docuware/openapi-handmade.json
       Namespace: com.axonivy.connector.docuware.connector.model

--- a/docuware-connector/config/rest-clients.yaml
+++ b/docuware-connector/config/rest-clients.yaml
@@ -13,11 +13,11 @@ RestClients:
       Password: ${ivy.var.docuware-connector.password}
       HostId: ${ivy.var.docuware-connector.hostid}
       LogonUrl: ${ivy.var.docuware-connector.logonurl}
+      Organization: ${ivy.var.docuware-connector.organization}
       com.sun.jersey.impl.client.httpclient.handleCookies: 'true'
       http.protocol.handle-redirects: 'true'
       JSON.Serialization.PROPERTY_INCLUSION: NON_NULL
       jersey.config.client.connectTimeout: ${ivy.var.docuware-connector.connectTimeout}
-      Organization: ${ivy.var.docuware-connector.organization}
     OpenAPI:
       SpecUrl: file:///X:/AxonIvy/marketplace/docuware/openapi-handmade.json
       Namespace: com.axonivy.connector.docuware.connector.model

--- a/docuware-connector/config/variables.yaml
+++ b/docuware-connector/config/variables.yaml
@@ -26,12 +26,11 @@ Variables:
     # Only set this value, if the automatic determination does not work.
     logonurl: ''
     
+    # Your organization name
+    organization: ''
+    
     filecabinetid: ''
     
     # This property sets the maximum time (in milliseconds) that the client will wait when attempting to establish a connection with the server.
     # The value MUST be an instance convertible to Integer. A value of zero (0) is equivalent to an interval of infinity.
-    connectTimeout: 0
-    
-    # Your organization name
-    organization: ''
-    
+    connectTimeout: 0    

--- a/docuware-connector/config/variables.yaml
+++ b/docuware-connector/config/variables.yaml
@@ -32,3 +32,5 @@ Variables:
     # The value MUST be an instance convertible to Integer. A value of zero (0) is equivalent to an interval of infinity.
     connectTimeout: 0
     
+    organization:
+    

--- a/docuware-connector/config/variables.yaml
+++ b/docuware-connector/config/variables.yaml
@@ -32,5 +32,6 @@ Variables:
     # The value MUST be an instance convertible to Integer. A value of zero (0) is equivalent to an interval of infinity.
     connectTimeout: 0
     
-    organization:
+    # Your organization name
+    organization: ''
     

--- a/docuware-connector/src/com/axonivy/connector/docuware/connector/DocuWareAuthFeature.java
+++ b/docuware-connector/src/com/axonivy/connector/docuware/connector/DocuWareAuthFeature.java
@@ -45,6 +45,7 @@ public class DocuWareAuthFeature implements Feature, ClientRequestFilter, Client
     String PASSWORD = "Password";
     String HOSTID = "HostId";
     String LOGONURL = "LogonUrl";
+    String ORGANIZATION = "Organization";
   }
 
   @Override
@@ -69,6 +70,10 @@ public class DocuWareAuthFeature implements Feature, ClientRequestFilter, Client
         .param("Password", config.readMandatory(Property.PASSWORD))
         .param("HostID", config.readMandatory(Property.HOSTID))
         .param("RedirectToMyselfInCaseOfError", "false");
+      String organization = config.read(Property.ORGANIZATION).orElse(null);
+      if (StringUtils.isNotBlank(organization)) {
+        form.param("Organization", organization);
+      }
       String logonUrl = getLogonUrl(reqContext, config);
       if (logonUrl == null) {
       }


### PR DESCRIPTION
Hi @ivy-rew 
after the previous PR to get the error message from Docuware https://github.com/axonivy-market/docuware-connector/pull/49/files, we detect that the logon request required 1 more param of "organization" 
![image](https://github.com/user-attachments/assets/e831b37e-aa72-45e2-a792-db768743efc1)

But in our dev account, the param of "organization" in logon request is not required so I let it as an optional param.
I would happy if you have a quick look on it before we release a new version with this attr.
Thanks. 