### PR TITLE
feat/MARP-1280: Add Class for Keywords data type

### DIFF
--- a/docuware-connector-demo/processes/DocuWareDemo.p.json
+++ b/docuware-connector-demo/processes/DocuWareDemo.p.json
@@ -796,6 +796,7 @@
             "param.configuration.fileCabinetId" : "in.cabinet.id"
           },
           "code" : [
+            "import com.axonivy.connector.docuware.connector.DocuWareKeywordsField;",
             "import com.axonivy.connector.docuware.connector.DocuWareFieldTableItem;",
             "import com.axonivy.connector.docuware.connector.DocuWareEndpointConfiguration;",
             "import com.axonivy.connector.docuware.connector.demo.DocuWareDemoService;",
@@ -822,6 +823,13 @@
             "",
             "DocuWareProperty dwtp = new DocuWareProperty(\"LINE___ITEM\", dwt, \"Table\");",
             "properties.add(dwtp);",
+            "",
+            "DocuWareKeywordsField keywordField = new DocuWareKeywordsField();",
+            "keywordField.append(\"1st Keyword\");",
+            "keywordField.append(\"2nd Keyword\");",
+            "",
+            "DocuWareProperty keywordProperty = new DocuWareProperty(\"VALIDATION_CHECK\", keywordField, \"Keywords\");",
+            "properties.add(keywordProperty);",
             "",
             "param.indexFields = properties;"
           ]

--- a/docuware-connector-test/src_test/com/axonivy/market/docuware/connector/test/TestDocuWareConnector.java
+++ b/docuware-connector-test/src_test/com/axonivy/market/docuware/connector/test/TestDocuWareConnector.java
@@ -3,6 +3,7 @@ package com.axonivy.market.docuware.connector.test;
 import com.axonivy.connector.docuware.connector.DocuWareAuthFeature;
 import com.axonivy.connector.docuware.connector.DocuWareEndpointConfiguration;
 import com.axonivy.connector.docuware.connector.DocuWareFieldTableItem;
+import com.axonivy.connector.docuware.connector.DocuWareKeywordsField;
 import com.axonivy.connector.docuware.connector.DocuWareProperty;
 
 import ch.ivyteam.ivy.application.IApplication;
@@ -56,6 +57,12 @@ public class TestDocuWareConnector {
     ;
     DocuWareProperty dwtp = new DocuWareProperty("EMPLOYEE_NOTES", dwt, "Table");
     propertyList.add(dwtp);
+    
+    DocuWareKeywordsField keywordField = new DocuWareKeywordsField();
+    keywordField.append("1st Keyword");
+    keywordField.append("2nd Keyword");
+    DocuWareProperty keywordProperty = new DocuWareProperty("TAGS", keywordField, "Keywords");
+    propertyList.add(keywordProperty);
     
     return propertyList;
   }

--- a/docuware-connector/src/com/axonivy/connector/docuware/connector/DocuWareKeywordsField.java
+++ b/docuware-connector/src/com/axonivy/connector/docuware/connector/DocuWareKeywordsField.java
@@ -1,0 +1,56 @@
+package com.axonivy.connector.docuware.connector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * DocuWareKeywordsField class to match the JSON format used by the Docuware rest
+ * services for setting item value of {@link DocuWareProperty} which
+ * type="Keywords".
+ */
+@JsonPropertyOrder({ "$type", "Keyword" })
+public class DocuWareKeywordsField {
+
+	@JsonProperty(value = "$type")
+	final private String type = "DocumentIndexFieldKeywords";
+
+	@JsonProperty(value = "Keyword")
+	private List<String> keywords;
+
+	public DocuWareKeywordsField() {
+		keywords = new ArrayList<>();
+	}
+
+	/**
+	 * @return the keywords
+	 */
+	public List<String> getKeywords() {
+		return keywords;
+	}
+
+	/**
+	 * @param keywords the keywords to set
+	 */
+	public void setKeywords(List<String> keywords) {
+		this.keywords = keywords;
+	}
+
+	/**
+	 * @return the type
+	 */
+	public String getType() {
+		return type;
+	}
+
+	public void append(String value) {
+		if (Objects.isNull(keywords)) {
+			keywords = new ArrayList<>();
+		}
+		keywords.add(value);
+	}
+
+}

--- a/docuware-connector/src/com/axonivy/connector/docuware/connector/DocuWareKeywordsField.java
+++ b/docuware-connector/src/com/axonivy/connector/docuware/connector/DocuWareKeywordsField.java
@@ -46,6 +46,11 @@ public class DocuWareKeywordsField {
 		return type;
 	}
 
+	/**
+	 * 
+	 * @param value
+	 * Utility function to add keyword to the list
+	 */
 	public void append(String value) {
 		if (Objects.isNull(keywords)) {
 			keywords = new ArrayList<>();


### PR DESCRIPTION
Add new class `DocuwareKeywordsField` to support to indexing the DocuWare fields which have type `Keywords`.